### PR TITLE
feat: Save and lookup sourcesContents in the Cache

### DIFF
--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -2,7 +2,7 @@ use zerocopy::LayoutVerified;
 
 use crate::{ScopeLookupResult, SourcePosition};
 
-use super::raw::{self, LineOffset};
+use super::raw;
 
 /// A resolved Source Location  with file, line and scope information.
 #[derive(Debug, PartialEq)]
@@ -170,7 +170,7 @@ pub enum Error {
 
 pub struct File<'data> {
     source: &'data str,
-    line_offsets: &'data [LineOffset],
+    line_offsets: &'data [raw::LineOffset],
 }
 
 impl<'data> File<'data> {

--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -2,7 +2,7 @@ use zerocopy::LayoutVerified;
 
 use crate::{ScopeLookupResult, SourcePosition};
 
-use super::raw;
+use super::raw::{self, LineOffset};
 
 /// A resolved Source Location  with file, line and scope information.
 #[derive(Debug, PartialEq)]
@@ -21,6 +21,8 @@ pub struct SmCache<'data> {
     header: &'data raw::Header,
     min_source_positions: &'data [raw::MinifiedSourcePosition],
     orig_source_locations: &'data [raw::OriginalSourceLocation],
+    files: &'data [raw::File],
+    line_offsets: &'data [raw::LineOffset],
     string_bytes: &'data [u8],
 }
 
@@ -29,6 +31,8 @@ impl<'data> std::fmt::Debug for SmCache<'data> {
         f.debug_struct("SmCache")
             .field("version", &self.header.version)
             .field("mappings", &self.header.num_mappings)
+            .field("files", &self.header.num_files)
+            .field("line_offsets", &self.header.num_line_offsets)
             .field("string_bytes", &self.header.string_bytes)
             .finish()
     }
@@ -39,6 +43,7 @@ impl<'data> SmCache<'data> {
         let (header, buf): (LayoutVerified<_, raw::Header>, _) =
             LayoutVerified::new_from_prefix(buf).ok_or(Error::Header)?;
         let header = header.into_ref();
+        let buf = align_buf(buf);
 
         if header.magic == raw::SMCACHE_MAGIC_FLIPPED {
             return Err(Error::WrongEndianness);
@@ -51,17 +56,36 @@ impl<'data> SmCache<'data> {
         }
 
         let num_mappings = header.num_mappings as usize;
-        let string_bytes = header.string_bytes as usize;
         let (min_source_positions, buf) = LayoutVerified::new_slice_from_prefix(buf, num_mappings)
             .ok_or(Error::SourcePositions)?;
+        let min_source_positions = min_source_positions.into_slice();
+        let buf = align_buf(buf);
+
         let (orig_source_locations, buf) = LayoutVerified::new_slice_from_prefix(buf, num_mappings)
             .ok_or(Error::SourceLocations)?;
+        let orig_source_locations = orig_source_locations.into_slice();
+        let buf = align_buf(buf);
+
+        let (files, buf) = LayoutVerified::new_slice_from_prefix(buf, header.num_files as usize)
+            .ok_or(Error::SourceLocations)?;
+        let files = files.into_slice();
+        let buf = align_buf(buf);
+
+        let (line_offsets, buf) =
+            LayoutVerified::new_slice_from_prefix(buf, header.num_line_offsets as usize)
+                .ok_or(Error::SourceLocations)?;
+        let line_offsets = line_offsets.into_slice();
+        let buf = align_buf(buf);
+
+        let string_bytes = header.string_bytes as usize;
         let string_bytes = buf.get(..string_bytes).ok_or(Error::StringBytes)?;
 
         Ok(Self {
             header,
-            min_source_positions: min_source_positions.into_slice(),
-            orig_source_locations: orig_source_locations.into_slice(),
+            min_source_positions,
+            orig_source_locations,
+            files,
+            line_offsets,
             string_bytes,
         })
     }
@@ -101,9 +125,29 @@ impl<'data> SmCache<'data> {
         Some(SourceLocation { file, line, scope })
     }
 
-    // TODO:
-    // pub fn get_file(&self, name: &str) -> Option<File>
-    // pub fn File::get_line(&self, line_no: u32/usize) -> Option<&'str>
+    /// Returns the [`File`] which allows fast access to source lines.
+    pub fn get_file(&self, name: &str) -> Option<File> {
+        let file_idx = self
+            .files
+            .binary_search_by_key(&name, |file| {
+                // TODO: decoding the string here might be expensive.
+                // however, doing that ahead of time when loading the file is
+                // expensive too, so this is a tradeoff we could potentially measure.
+                self.get_string(file.name_offset).unwrap_or("")
+            })
+            .ok()?;
+        let file = self.files.get(file_idx)?;
+
+        let source = self.get_string(file.source_offset)?;
+        let line_offsets = self
+            .line_offsets
+            .get(file.line_offsets_start as usize..file.line_offsets_end as usize)?;
+
+        Some(File {
+            source,
+            line_offsets,
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -122,4 +166,28 @@ pub enum Error {
     SourcePositions,
     SourceLocations,
     StringBytes,
+}
+
+pub struct File<'data> {
+    source: &'data str,
+    line_offsets: &'data [LineOffset],
+}
+
+impl<'data> File<'data> {
+    /// Returns the source of this file.
+    pub fn get_source(&self) -> &str {
+        self.source
+    }
+
+    /// Returns the requested source line if possible.
+    pub fn get_line(&self, line_no: usize) -> Option<&str> {
+        let from = self.line_offsets.get(line_no).copied()?.0 as usize;
+        let to = self.line_offsets.get(line_no.checked_add(1)?).copied()?.0 as usize;
+        self.source.get(from..to)
+    }
+}
+
+fn align_buf(buf: &[u8]) -> &[u8] {
+    let offset = buf.as_ptr().align_offset(8);
+    buf.get(offset..).unwrap_or(&[])
 }

--- a/src/smcache/raw.rs
+++ b/src/smcache/raw.rs
@@ -75,6 +75,25 @@ pub struct OriginalSourceLocation {
     pub scope_idx: u32,
 }
 
+/// A minified source position of line/column.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromBytes, AsBytes)]
+#[repr(C)]
+pub struct File {
+    /// The source filename (offset into string table).
+    pub name_offset: u32,
+    /// The file contents (offset into string table).
+    pub source_offset: u32,
+    /// Start of the line offsets (index into line offsets table).
+    pub line_offsets_start: u32,
+    /// End of the line offsets (index into line offsets table).
+    pub line_offsets_end: u32,
+}
+
+/// An offset into each files content representing line boundaries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromBytes, AsBytes)]
+#[repr(C)]
+pub struct LineOffset(pub u32);
+
 /// Returns the amount left to add to the remainder to get 8 if
 /// `to_align` isn't a multiple of 8.
 pub fn align_to_eight(to_align: usize) -> usize {

--- a/src/smcache/writer.rs
+++ b/src/smcache/writer.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::io::Write;
 
 use sourcemap::DecodedMap;
@@ -15,7 +15,8 @@ use raw::{ANONYMOUS_SCOPE_SENTINEL, GLOBAL_SCOPE_SENTINEL, NO_FILE_SENTINEL};
 /// to the original [`raw::OriginalSourceLocation`] it maps to.
 pub struct SmCacheWriter {
     string_bytes: Vec<u8>,
-
+    files: Vec<raw::File>,
+    line_offsets: Vec<raw::LineOffset>,
     mappings: Vec<(raw::MinifiedSourcePosition, raw::OriginalSourceLocation)>,
 }
 
@@ -136,25 +137,43 @@ impl SmCacheWriter {
             last = Some(sl);
         }
 
-        // TODO: iterate over all the `sourcesContent` files embedded in the
-        // source map, and generate file entries for those, with line offsets,
-        // similar to how `SourceContext` works.
-
-        let mut files = BTreeMap::new();
         let orig_files = match &sm {
             DecodedMap::Regular(sm) => sm.sources().zip(sm.source_contents()),
             DecodedMap::Hermes(smh) => smh.sources().zip(smh.source_contents()),
             DecodedMap::Index(_smi) => unreachable!(),
-        };
-
-        for (filename, contents) in orig_files {
-            // TODO
-            files.insert(filename.to_owned(), contents.to_owned());
         }
-        dbg!(files);
+        .filter_map(|(name, source)| source.map(|source| (name, source)));
+
+        let mut line_offsets = vec![];
+        let mut files = vec![];
+        for (name, source) in orig_files {
+            let name_offset = Self::insert_string(&mut string_bytes, &mut strings, name);
+            let source_offset = Self::insert_string(&mut string_bytes, &mut strings, source);
+            let line_offsets_start = line_offsets.len() as u32;
+            let buf_ptr = source.as_ptr();
+            line_offsets.extend(source.lines().map(|line| {
+                raw::LineOffset(unsafe { line.as_ptr().offset_from(buf_ptr) as usize } as u32)
+            }));
+            line_offsets.push(raw::LineOffset(source.len() as u32));
+            let line_offsets_end = line_offsets.len() as u32;
+
+            files.push((
+                name,
+                raw::File {
+                    name_offset,
+                    source_offset,
+                    line_offsets_start,
+                    line_offsets_end,
+                },
+            ));
+        }
+        files.sort_by_key(|(name, _file)| *name);
+        let files = files.into_iter().map(|(_name, file)| file).collect();
 
         Ok(Self {
             string_bytes,
+            files,
+            line_offsets,
             mappings,
         })
     }
@@ -190,16 +209,13 @@ impl SmCacheWriter {
     pub fn serialize<W: Write>(self, writer: &mut W) -> std::io::Result<()> {
         let mut writer = WriteWrapper::new(writer);
 
-        let num_mappings = self.mappings.len() as u32;
-        let string_bytes = self.string_bytes.len() as u32;
-
         let header = raw::Header {
             magic: raw::SMCACHE_MAGIC,
             version: raw::SMCACHE_VERSION,
-            num_mappings,
-            num_files: 0,
-            num_line_offsets: 0,
-            string_bytes,
+            num_mappings: self.mappings.len() as u32,
+            num_files: self.files.len() as u32,
+            num_line_offsets: self.line_offsets.len() as u32,
+            string_bytes: self.string_bytes.len() as u32,
             _reserved: [0; 8],
         };
 
@@ -214,6 +230,12 @@ impl SmCacheWriter {
         for (_, orig_sl) in self.mappings {
             writer.write(orig_sl.as_bytes())?;
         }
+        writer.align()?;
+
+        writer.write(self.files.as_bytes())?;
+        writer.align()?;
+
+        writer.write(self.line_offsets.as_bytes())?;
         writer.align()?;
 
         writer.write(&self.string_bytes)?;

--- a/src/smcache/writer.rs
+++ b/src/smcache/writer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
 
 use sourcemap::DecodedMap;
@@ -139,6 +139,19 @@ impl SmCacheWriter {
         // TODO: iterate over all the `sourcesContent` files embedded in the
         // source map, and generate file entries for those, with line offsets,
         // similar to how `SourceContext` works.
+
+        let mut files = BTreeMap::new();
+        let orig_files = match &sm {
+            DecodedMap::Regular(sm) => sm.sources().zip(sm.source_contents()),
+            DecodedMap::Hermes(smh) => smh.sources().zip(smh.source_contents()),
+            DecodedMap::Index(_smi) => unreachable!(),
+        };
+
+        for (filename, contents) in orig_files {
+            // TODO
+            files.insert(filename.to_owned(), contents.to_owned());
+        }
+        dbg!(files);
 
         Ok(Self {
             string_bytes,

--- a/tests/fixtures/simple/minified.js.map
+++ b/tests/fixtures/simple/minified.js.map
@@ -1,1 +1,1 @@
-{"version":3,"names":["abcd"],"sources":["tests/fixtures/simple/original.js"],"mappings":"AACA,SAASA,oBACMA"}
+{"version":3,"names":["abcd"],"sources":["tests/fixtures/simple/original.js"],"sourcesContent":["// ./node_modules/.bin/terser -c -m --module tests/fixtures/simple/original.js --source-map includeSources -o tests/fixtures/simple/minified.js\nfunction abcd() {}\nexport default abcd;\n"],"mappings":"AACA,SAASA,oBACMA"}

--- a/tests/fixtures/simple/original.js
+++ b/tests/fixtures/simple/original.js
@@ -1,3 +1,3 @@
-// ./node_modules/.bin/terser -c -m --module tests/fixtures/simple/original.js --source-map -o tests/fixtures/simple/minified.js
+// ./node_modules/.bin/terser -c -m --module tests/fixtures/simple/original.js --source-map includeSources -o tests/fixtures/simple/minified.js
 function abcd() {}
 export default abcd;


### PR DESCRIPTION
Persists all the source contents and their line offsets into the binary cache. 
This allows for quick access to source lines (though looking up the file might be expensive).