### PR TITLE
ref: Refactor file handling

### DIFF
--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -8,11 +8,49 @@ use super::raw;
 #[derive(Debug, PartialEq)]
 pub struct SourceLocation<'data> {
     /// The source file this location belongs to.
-    pub file: Option<&'data str>,
+    file: Option<File<'data>>,
     /// The source line.
-    pub line: u32,
+    line: u32,
     /// The scope containing this source location.
-    pub scope: ScopeLookupResult<'data>,
+    scope: ScopeLookupResult<'data>,
+}
+
+impl<'data> SourceLocation<'data> {
+    /// The source file this location belongs to.
+    pub fn file(&self) -> Option<File<'data>> {
+        self.file
+    }
+
+    /// The source line.
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+
+    /// The scope containing this source location.
+    pub fn scope(&self) -> ScopeLookupResult<'data> {
+        self.scope
+    }
+
+    /// The name of the source file this location belongs to.
+    ///
+    /// This is short for `self.file.as_ref().map(|file| file.name())`.
+    pub fn file_name(&self) -> Option<&'data str> {
+        self.file.as_ref().map(|file| file.name)
+    }
+
+    /// The source of the file this location belongs to.
+    ///
+    /// This is short for `self.file.as_ref().map(|file| file.source())`.
+    pub fn file_source(&self) -> Option<&'data str> {
+        self.file.as_ref().map(|file| file.source)
+    }
+
+    /// Returns the requested source line, if possible.
+    ///
+    /// This is short for `self.file.as_ref().and_then(|file| file.line(line_no))`.
+    pub fn source_line(&self, line_no: usize) -> Option<&'data str> {
+        self.file.as_ref().and_then(|file| file.line(line_no))
+    }
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -111,8 +149,20 @@ impl<'data> SmCache<'data> {
 
         let sl = self.orig_source_locations.get(idx)?;
 
-        let file = self.get_string(sl.file_idx);
         let line = sl.line;
+
+        let file = self.files.get(sl.file_idx as usize).and_then(|raw_file| {
+            let name = self.get_string(raw_file.name_offset)?;
+            let source = self.get_string(raw_file.source_offset)?;
+            let line_offsets = self
+                .line_offsets
+                .get(raw_file.line_offsets_start as usize..raw_file.line_offsets_end as usize)?;
+            Some(File {
+                name,
+                source,
+                line_offsets,
+            })
+        });
 
         let scope = match sl.scope_idx {
             raw::GLOBAL_SCOPE_SENTINEL => ScopeLookupResult::Unknown,
@@ -123,30 +173,6 @@ impl<'data> SmCache<'data> {
         };
 
         Some(SourceLocation { file, line, scope })
-    }
-
-    /// Returns the [`File`] which allows fast access to source lines.
-    pub fn get_file(&self, name: &str) -> Option<File> {
-        let file_idx = self
-            .files
-            .binary_search_by_key(&name, |file| {
-                // TODO: decoding the string here might be expensive.
-                // however, doing that ahead of time when loading the file is
-                // expensive too, so this is a tradeoff we could potentially measure.
-                self.get_string(file.name_offset).unwrap_or("")
-            })
-            .ok()?;
-        let file = self.files.get(file_idx)?;
-
-        let source = self.get_string(file.source_offset)?;
-        let line_offsets = self
-            .line_offsets
-            .get(file.line_offsets_start as usize..file.line_offsets_end as usize)?;
-
-        Some(File {
-            source,
-            line_offsets,
-        })
     }
 }
 
@@ -168,19 +194,26 @@ pub enum Error {
     StringBytes,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct File<'data> {
+    name: &'data str,
     source: &'data str,
     line_offsets: &'data [raw::LineOffset],
 }
 
 impl<'data> File<'data> {
+    /// Returns the name of this file.
+    pub fn name(&self) -> &'data str {
+        self.name
+    }
+
     /// Returns the source of this file.
-    pub fn get_source(&self) -> &str {
+    pub fn source(&self) -> &'data str {
         self.source
     }
 
     /// Returns the requested source line if possible.
-    pub fn get_line(&self, line_no: usize) -> Option<&str> {
+    pub fn line(&self, line_no: usize) -> Option<&'data str> {
         let from = self.line_offsets.get(line_no).copied()?.0 as usize;
         let to = self.line_offsets.get(line_no.checked_add(1)?).copied()?.0 as usize;
         self.source.get(from..to)

--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -44,13 +44,6 @@ impl<'data> SourceLocation<'data> {
     pub fn file_source(&self) -> Option<&'data str> {
         self.file.as_ref().map(|file| file.source)
     }
-
-    /// Returns the requested source line, if possible.
-    ///
-    /// This is short for `self.file.as_ref().and_then(|file| file.line(line_no))`.
-    pub fn source_line(&self, line_no: usize) -> Option<&'data str> {
-        self.file.as_ref().and_then(|file| file.line(line_no))
-    }
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -21,9 +21,14 @@ impl<'data> SourceLocation<'data> {
         self.file
     }
 
-    /// The source line.
+    /// The number of the source line.
     pub fn line(&self) -> u32 {
         self.line
+    }
+
+    /// The contents of the source line.
+    pub fn line_contents(&self) -> Option<&'data str> {
+        self.file().and_then(|file| file.line(self.line as usize))
     }
 
     /// The scope containing this source location.
@@ -168,6 +173,8 @@ impl<'data> SmCache<'data> {
         };
 
         Some(SourceLocation { file, line, scope })
+    }
+
     /// Returns an iterator over all files in the cache.
     pub fn files(&self) -> Files<'data> {
         Files::new(self)

--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -33,12 +33,12 @@ impl<'data> SourceLocation<'data> {
 
     /// The name of the source file this location belongs to.
     pub fn file_name(&self) -> Option<&'data str> {
-        self.file.as_ref().map(|file| file.name)
+        self.file.map(|file| file.name)
     }
 
     /// The source of the file this location belongs to.
     pub fn file_source(&self) -> Option<&'data str> {
-        self.file.as_ref().map(|file| file.source)
+        self.file.map(|file| file.source)
     }
 }
 

--- a/src/smcache/lookup.rs
+++ b/src/smcache/lookup.rs
@@ -32,15 +32,11 @@ impl<'data> SourceLocation<'data> {
     }
 
     /// The name of the source file this location belongs to.
-    ///
-    /// This is short for `self.file.as_ref().map(|file| file.name())`.
     pub fn file_name(&self) -> Option<&'data str> {
         self.file.as_ref().map(|file| file.name)
     }
 
     /// The source of the file this location belongs to.
-    ///
-    /// This is short for `self.file.as_ref().map(|file| file.source())`.
     pub fn file_source(&self) -> Option<&'data str> {
         self.file.as_ref().map(|file| file.source)
     }

--- a/src/smcache/raw.rs
+++ b/src/smcache/raw.rs
@@ -67,7 +67,7 @@ pub const ANONYMOUS_SCOPE_SENTINEL: u32 = u32::MAX - 1;
 #[derive(Clone, Copy, Debug, PartialEq, FromBytes, AsBytes)]
 #[repr(C)]
 pub struct OriginalSourceLocation {
-    /// The optional original source filename (offset into string table).
+    /// The optional original source file (index in the file table).
     pub file_idx: u32,
     /// The original line number.
     pub line: u32,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -174,10 +174,7 @@ fn writes_simple_cache() {
     assert_eq!(sl.file_name(), Some("tests/fixtures/simple/original.js"));
     assert_eq!(sl.line(), 1);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("abcd"));
-    assert_eq!(
-        sl.source_line(sl.line() as usize).unwrap(),
-        "function abcd() {}\n"
-    );
+    assert_eq!(sl.line_contents().unwrap(), "function abcd() {}\n");
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 use js_source_scopes::{
     extract_scope_names, NameResolver, ScopeIndex, ScopeLookupResult, SourceContext, SourcePosition,
 };
-use js_source_scopes::{SmCache, SmCacheWriter, SourceLocation};
+use js_source_scopes::{SmCache, SmCacheWriter};
 
 #[test]
 fn resolves_scope_names() {
@@ -171,20 +171,13 @@ fn writes_simple_cache() {
 
     let sl = cache.lookup(SourcePosition::new(0, 10)).unwrap();
 
+    assert_eq!(sl.file_name(), Some("tests/fixtures/simple/original.js"));
+    assert_eq!(sl.line(), 1);
+    assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("abcd"));
     assert_eq!(
-        sl,
-        SourceLocation {
-            file: Some("tests/fixtures/simple/original.js"),
-            line: 1,
-            scope: ScopeLookupResult::NamedScope("abcd"),
-        }
+        sl.source_line(sl.line() as usize).unwrap(),
+        "function abcd() {}\n"
     );
-
-    let file = cache.get_file(sl.file.unwrap()).unwrap();
-
-    let source_line = file.get_line(sl.line as usize).unwrap();
-
-    assert_eq!(source_line, "function abcd() {}\n");
 }
 
 #[test]
@@ -206,48 +199,28 @@ fn resolves_location_from_cache() {
         cache.lookup(SourcePosition::new(l - 1, c - 1))
     };
 
-    assert_eq!(
-        lookup(1, 50),
-        Some(SourceLocation {
-            file: Some("../src/constants.js"),
-            line: 2,
-            scope: Unknown,
-        })
-    );
+    let sl = lookup(1, 50).unwrap();
+    assert_eq!(sl.file_name(), Some("../src/constants.js"));
+    assert_eq!(sl.line(), 2);
+    assert_eq!(sl.scope(), Unknown);
 
-    assert_eq!(
-        lookup(1, 133),
-        Some(SourceLocation {
-            file: Some("../src/util.js"),
-            line: 11,
-            scope: NamedScope("assign")
-        })
-    );
+    let sl = lookup(1, 133).unwrap();
+    assert_eq!(sl.file_name(), Some("../src/util.js"));
+    assert_eq!(sl.line(), 11);
+    assert_eq!(sl.scope(), NamedScope("assign"));
 
-    assert_eq!(
-        lookup(1, 482),
-        Some(SourceLocation {
-            file: Some("../src/create-element.js"),
-            line: 39,
-            scope: NamedScope("createElement")
-        })
-    );
+    let sl = lookup(1, 482).unwrap();
+    assert_eq!(sl.file_name(), Some("../src/create-element.js"));
+    assert_eq!(sl.line(), 39);
+    assert_eq!(sl.scope(), NamedScope("createElement"));
 
-    assert_eq!(
-        lookup(1, 9780),
-        Some(SourceLocation {
-            file: Some("../src/component.js"),
-            line: 181,
-            scope: Unknown
-        })
-    );
+    let sl = lookup(1, 9780).unwrap();
+    assert_eq!(sl.file_name(), Some("../src/component.js"));
+    assert_eq!(sl.line(), 181);
+    assert_eq!(sl.scope(), Unknown);
 
-    assert_eq!(
-        lookup(1, 9795),
-        Some(SourceLocation {
-            file: Some("../src/create-context.js"),
-            line: 2,
-            scope: Unknown
-        })
-    );
+    let sl = lookup(1, 9795).unwrap();
+    assert_eq!(sl.file_name(), Some("../src/create-context.js"));
+    assert_eq!(sl.line(), 2);
+    assert_eq!(sl.scope(), Unknown);
 }


### PR DESCRIPTION
The `file` of a returned `SourceLocation` is now no longer just the name that you can then use to look up the rest of the information, but the whole structure. This change is mirrored in the raw data structures: the `file_idx` no longer points to the file name, but the entire file structure. This makes it necessary to restructure `SmCacheWriter::new` so that file insertion happens first.

I also added some convenience methods and renamed some things.