### PR TITLE
fix(cache): Correct line offsets for files with trailing newlines

### DIFF
--- a/src/smcache/writer.rs
+++ b/src/smcache/writer.rs
@@ -119,11 +119,7 @@ impl SmCacheWriter {
             let name_offset = Self::insert_string(&mut string_bytes, &mut strings, name);
             let source_offset = Self::insert_string(&mut string_bytes, &mut strings, source);
             let line_offsets_start = line_offsets.len() as u32;
-            let buf_ptr = source.as_ptr();
-            line_offsets.extend(source.lines().map(|line| {
-                raw::LineOffset(unsafe { line.as_ptr().offset_from(buf_ptr) as usize } as u32)
-            }));
-            line_offsets.push(raw::LineOffset(source.len() as u32));
+            line_offsets.extend(Self::line_offsets(source));
             let line_offsets_end = line_offsets.len() as u32;
 
             files.push((
@@ -257,6 +253,23 @@ impl SmCacheWriter {
 
         Ok(())
     }
+
+    fn line_offsets(source: &str) -> impl Iterator<Item = raw::LineOffset> + '_ {
+        let buf_ptr = source.as_ptr();
+        source
+            .lines()
+            .map(move |line| {
+                raw::LineOffset(unsafe { line.as_ptr().offset_from(buf_ptr) as usize } as u32)
+            })
+            .chain(
+                // If the file ends with a line break, add another line offset for the empty last line
+                // (the lines iterator skips it).
+                source
+                    .ends_with('\n')
+                    .then(|| raw::LineOffset(source.len() as u32)),
+            )
+            .chain(std::iter::once(raw::LineOffset(source.len() as u32)))
+    }
 }
 
 /// An Error that can happen when building a [`SmCache`].
@@ -312,5 +325,67 @@ impl<W: Write> WriteWrapper<W> {
         let buf = &[0u8; 7];
         let len = raw::align_to_eight(self.position);
         self.write(&buf[0..len])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::smcache::raw::LineOffset;
+
+    use super::*;
+
+    #[test]
+    fn line_offsets_empty_file() {
+        let source = "";
+
+        let line_offsets = SmCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        assert_eq!(line_offsets, [LineOffset(0), LineOffset(0)]);
+    }
+
+    #[test]
+    fn line_offsets_almost_empty_file() {
+        let source = "\n";
+
+        let line_offsets = SmCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        assert_eq!(line_offsets, [LineOffset(0), LineOffset(1), LineOffset(1)]);
+    }
+
+    #[test]
+    fn line_offsets_several_lines() {
+        let source = "a\n\nb\nc";
+
+        let line_offsets = SmCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        assert_eq!(
+            line_offsets,
+            [
+                LineOffset(0),
+                LineOffset(2),
+                LineOffset(3),
+                LineOffset(5),
+                LineOffset(6)
+            ]
+        );
+    }
+
+    #[test]
+    fn line_offsets_several_lines_trailing_newline() {
+        let source = "a\n\nb\nc\n";
+
+        let line_offsets = SmCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        assert_eq!(
+            line_offsets,
+            [
+                LineOffset(0),
+                LineOffset(2),
+                LineOffset(3),
+                LineOffset(5),
+                LineOffset(7),
+                LineOffset(7)
+            ]
+        );
     }
 }


### PR DESCRIPTION
The test for the empty file fails right now—I think the empty file should have two line offsets (both `0`), but as written there's only one. I think both variants are defensible: does the empty file have no lines, or one empty line?