### PR TITLE
fix: Ensure exact token match in NameResolver

### DIFF
--- a/src/name_resolver.rs
+++ b/src/name_resolver.rs
@@ -32,6 +32,12 @@ impl<'a, T: AsRef<str>> NameResolver<'a, T> {
         let token = self
             .sourcemap
             .lookup_token(source_position.line, source_position.column)?;
-        token.get_name()
+        let is_exact_match = token.get_dst() == (source_position.line, source_position.column);
+
+        if is_exact_match {
+            token.get_name()
+        } else {
+            None
+        }
     }
 }

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,3 +1,11 @@
+# Minifying code and creating SourceMaps:
+
+For example:
+
+```
+./node_modules/.bin/terser -c -m --module tests/fixtures/simple/original.js --source-map includeSources -o tests/fixtures/simple/minified.js
+```
+
 # trace
 
 A sync and async stack trace through various constructs, with named and anonymous

--- a/tests/fixtures/prototype-chain/README.md
+++ b/tests/fixtures/prototype-chain/README.md
@@ -1,0 +1,5 @@
+The SourceMap was hand-edited to remove the `prototype` token:
+
+The `EAAIC,UAAUC` portion in the middle of the mappings was replaced by `YAAcC`,
+as well as the `IAAKF,GAAKE` portion at the end was replaced by `IAAKD,GAAKC`,
+and the `"prototype"` was removed from `names`.

--- a/tests/fixtures/prototype-chain/minified.js
+++ b/tests/fixtures/prototype-chain/minified.js
@@ -1,0 +1,1 @@
+function t(){}t.prototype.bar=()=>{};export default(new t).bar();

--- a/tests/fixtures/prototype-chain/minified.js.map
+++ b/tests/fixtures/prototype-chain/minified.js.map
@@ -1,0 +1,1 @@
+{"version":3,"names":["Foo","bar"],"sources":["tests/fixtures/prototype-chain/original.js"],"sourcesContent":["function Foo() {}\nFoo.prototype.bar = () => {};\nexport default (new Foo).bar();"],"mappings":"AAAA,SAASA,KACTA,YAAcC,IAAM,sBACL,IAAKD,GAAKC"}

--- a/tests/fixtures/prototype-chain/original.js
+++ b/tests/fixtures/prototype-chain/original.js
@@ -1,0 +1,3 @@
+function Foo() {}
+Foo.prototype.bar = () => {};
+export default (new Foo).bar();


### PR DESCRIPTION
Previously we would use *any* preceding token from the SourceMap, and may end up outputting `Foo.Foo.bar` for `Foo.prototype.bar` when the `prototype` token itself does not appear precisely in the SourceMap.