### PR TITLE
fix: Correctly handle scope names for nested objects

### DIFF
--- a/src/swc.rs
+++ b/src/swc.rs
@@ -213,6 +213,7 @@ fn infer_name_from_ctx(path: &AstNodePath) -> ScopeName {
             // An object literal member:
             // `{ $name() ... }`
             Parent::MethodProp(method, _) => {
+                push_sep(&mut scope_name);
                 scope_name
                     .components
                     .push_front(prop_name_to_component(&method.key));
@@ -222,6 +223,7 @@ fn infer_name_from_ctx(path: &AstNodePath) -> ScopeName {
             // `{ $name: ... }`
             Parent::KeyValueProp(kv, _) => {
                 if let Some(ident) = kv.key.as_ident() {
+                    push_sep(&mut scope_name);
                     scope_name
                         .components
                         .push_front(NameComponent::ident(ident.clone()));

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -228,3 +228,29 @@ fn extract_empty_function() {
     let expected = [None, None];
     assert_eq!(scopes, expected);
 }
+
+#[test]
+fn extract_nested_iife_objects() {
+    // NOTE: This mimicks what react-dom does to transpile JSX children into render tree.
+    let src = r#"
+        (function () {})({
+          children: (function () {})({
+            children: (function () {})({
+              onSubmitError () {
+                throw new Error('wat')
+              }
+            })
+          })
+        })
+        "#;
+    let scopes = extract_scope_names(src).unwrap();
+    let scopes = scope_strs(scopes);
+
+    let expected = [
+        None,
+        Some("<object>.children".into()),
+        Some("<object>.children.children".into()),
+        Some("<object>.children.children.onSubmitError".into()),
+    ];
+    assert_eq!(scopes, expected);
+}


### PR DESCRIPTION
Fixes https://github.com/getsentry/js-source-scopes/issues/17