### PR TITLE
fix: Use saturating_sub in try_map_token to prevent overflow

### DIFF
--- a/src/name_resolver.rs
+++ b/src/name_resolver.rs
@@ -34,7 +34,7 @@ impl<'a, T: AsRef<str>> NameResolver<'a, T> {
             .lookup_token(source_position.line, source_position.column)?;
 
         let is_exactish_match = token.get_dst_line() == source_position.line
-            && token.get_dst_col() >= source_position.column - 1;
+            && token.get_dst_col() >= source_position.column.saturating_sub(1);
 
         if is_exactish_match {
             token.get_name()


### PR DESCRIPTION
When offset is resolved to column `0`, we'd perform `0-1`, where column is `u32`, which ends up with gibberish output for our use case.

```
thread 'main' panicked at 'attempt to subtract with overflow', src/name_resolver.rs:37:39
```