### PR TITLE
chore: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @getsentry/owners-stacktrace
+*   @getsentry/ingest


### PR DESCRIPTION
Not sure who `owners-stacktrace` is but it should be `ingest`.